### PR TITLE
add check for max allowed client body size

### DIFF
--- a/inc/Client.hpp
+++ b/inc/Client.hpp
@@ -2,25 +2,53 @@
 
 #include "../inc/StandardLibraries.hpp"
 #include "Structs.hpp"
+#include "../inc/parse_header.hpp"
+#include "../inc/request_handler.hpp"
+
+typedef struct s_resp {
+	std::map<std::string, std::string>	req_header;
+	Response							response;
+} t_resp;
+	
+
+typedef enum e_client_state {
+	IDLE,
+	DISCONNECT,
+	CLIENT_ERROR
+} t_client_state;
 
 class Client {
 public:
-	Client(ServerConfig config, int epoll_fd = -1, int fd = -1);
+	Client(std::vector<ServerConfig> configs, int epoll_fd = -1, int fd = -1);
 	Client(const Client &source) = default;
 	Client &operator=(const Client &source) = default;
 
 	void recvFrom();
 	void sendTo();
-	void handleCompleteRequest(int, int);
+	t_client_state getState();
+	void handlePost(
+		ServerConfig config,
+		std::map<std::string, std::string> &header_map,
+		size_t header_end);
+
+	void handleCompleteRequest(
+		ServerConfig config,
+		std::map<std::string, std::string> header_map,
+		size_t header_end,
+		size_t body_length,
+		int status);
+
+	void closeConnection(int epoll_fd, int client_fd);
 
 private:
-	ServerConfig	config;
+	std::vector<ServerConfig>	configs;
 	int				epoll_fd;
 	int				fd;
+	t_client_state	state;
 	std::string		recv_buf;
-	std::string		send_buf;
-	std::vector<std::string> recv_queue;
-	std::vector<std::string> send_queue;
+	// std::string		send_buf;
+	// std::vector<std::string> recv_queue;
+	std::vector<t_resp> send_queue;
 };
 
 typedef enum e_method {
@@ -29,3 +57,4 @@ typedef enum e_method {
 	DELETE,
 	ERROR
 }	t_method;
+

--- a/inc/StandardLibraries.hpp
+++ b/inc/StandardLibraries.hpp
@@ -14,8 +14,11 @@
 #include <sstream> // for istrinstream
 #include <stdexcept>
 #include <string>
+#include <string.h> //memset
 //#include <strings.h>
 #include <sys/epoll.h>
 #include <sys/socket.h>
+// #include <sys/types.h>
+#include <netdb.h> // struct addrinfo
 #include <unistd.h> // sleep()
 #include <vector>

--- a/notes.md
+++ b/notes.md
@@ -17,3 +17,10 @@ Not sure if we should follow c++11 (older), c++20 (newer) or some else standar, 
 -----------
 
 If we want to add cookies, config file needs session defined (on). For now, not included.
+
+
+-----------
+12/6/2025
+-----------
+* In HTTP 1.1 Connection: Keep-Alive is the default and Close is used if requested
+* Response is sent also in case of POST and DELETE (200 series codes)

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -1,12 +1,16 @@
 
 #include "../inc/Client.hpp"
-#include "../inc/request_handler.hpp"
-#include "../inc/Structs.hpp"
 
-Client::Client(ServerConfig config, int epoll_fd, int fd) :
-	config(config),
+Client::Client(std::vector<ServerConfig> configs, int epoll_fd, int fd) :
+	configs(configs),
 	epoll_fd(epoll_fd),
-	fd(fd)  {}
+	fd(fd)  {
+	state = IDLE;
+}
+
+t_client_state Client::getState() {
+	return state;
+}
 
 
 bool isCompleteHeader(std::string request) {
@@ -27,7 +31,8 @@ static void changeEpollMode(int epoll_fd, int client_fd, uint32_t mode) {
 	}
 }
 
-static void closeConnection(int epoll_fd, int client_fd) {
+// Client object is erased in event_loop() after the state is checked
+void Client::closeConnection(int epoll_fd, int client_fd) {
 	if (epoll_ctl(epoll_fd, EPOLL_CTL_DEL, client_fd, NULL) < 0) {
 		throw std::runtime_error("epoll_ctl() failed");
 	}
@@ -35,48 +40,73 @@ static void closeConnection(int epoll_fd, int client_fd) {
 	if (close(client_fd) < 0) {
 		throw std::runtime_error("failed to close() client_fd");
 	}
-}
-
-static t_method getRequestMethod(std::string request) {
-	std::istringstream	iss(request);
-	std::string			method;
-
-	iss >> method;
-	if (method == "GET") {
-		return GET;
-	} else if (method == "POST") {
-		return POST;
-	} else {
-		return ERROR;
-	}
+	state = DISCONNECT;
 }
 
 // TODO: suppor request pipelining
-void Client::handleCompleteRequest(int end, int body_length) {
+// TODO: 408: timeout
+// TODO: 411 => disconnect?
+// TODO: 413 => disconnect?
+void Client::handleCompleteRequest(
+	ServerConfig config, 
+	std::map<std::string, std::string> header_map,
+	size_t header_end,
+	size_t body_length,
+	int status)
+{
 	std::cout << "##### RECEIVED REQUEST #####" << std::endl;
-	std::cout << recv_buf.substr(0, end + body_length)<< std::endl;
+	std::cout << recv_buf.substr(0, header_end + body_length)<< std::endl;
 	std::cout << "############################" << std::endl;
 	
 	// TODO: sometimes the connection is closed without sending anything
 	// back? So we cannot always toggle to EPOLLOUT?
 	 
+	std::string whole_req = recv_buf.substr(0, header_end + body_length);
+	recv_buf.erase(0, header_end + body_length);
+	struct Response response = getResponse(whole_req, config, status);
+	t_resp resp = {header_map, response};
+	send_queue.push_back(resp);
 	
-	recv_queue.push_back(recv_buf.substr(0, end + body_length));
-	recv_buf.erase(0, end + body_length);
-	struct Response response = getResponse(recv_queue.front(), config, 0);
-	send_queue.push_back(response.full_response);
-	recv_queue.erase(recv_queue.begin());
-	
-	recv_buf = "";
+	// not emptying recv_buf here will allow pipelining?
+	// recv_buf = "";
 	// this will cause the event loop to trigger sendTo()
 	changeEpollMode(epoll_fd, fd, EPOLLOUT);
 }
 
+void Client::handlePost(
+	ServerConfig config,
+	std::map<std::string, std::string> &header_map,
+	size_t header_end)
+{
+	// TODO: would it be ok to try to receive everything and then
+	// later check if POST is even allowed
+	if (header_map.find("Content-Length") == header_map.end()) {
+		handleCompleteRequest(config, header_map, header_end, 0, 411);
+	} else {
+		size_t content_length = std::stoul(header_map.at("Content-Length"));
+		if (config.client_max_body_size != 0
+			&& content_length > config.client_max_body_size) {
+			std::cerr << "Client body length larger than allowed" << std::endl;
+			handleCompleteRequest(config, header_map, header_end, 0, 413);
+			// TODO: do we want to continue receiving?
+		} else if (recv_buf.length() >= header_end + content_length) {
+			std::cout << "Buf: " << recv_buf.length() << " target: "\
+				<< header_end << " + " << content_length << std::endl;
+			handleCompleteRequest(config, header_map, header_end, content_length, 0);
+		}
+		// if recv_buf is smaller than header + content length, we need to 
+		// receive more => we hall out of this function without doing anything
+	}
+	
+}
+
+// A client can have multiple configs, but request can only match one config
+// TODO: incomplete header -> timeout
 void Client::recvFrom() {
 	// sleep(1);
 	//std::cout << "entered recvFrom" << std::endl;
 	char buf[20] = {0};
-	std::string header_end = "\r\n\r\n";
+	std::string header_terminator = "\r\n\r\n";
 
 	int bytes_read = recv(fd, buf, sizeof(buf) -1, MSG_DONTWAIT);
 	// std::cout << "partial receive" << std::endl;
@@ -92,58 +122,90 @@ void Client::recvFrom() {
 	// an event anyway when the client closes the connection
 	if (bytes_read == 0) {
 		std::cout << "recvFrom(): read 0 bytes" << std::endl;
-		closeConnection(epoll_fd, fd);
+		closeConnection(epoll_fd,fd);
 		return ;
 	}
 
 	recv_buf += std::string(buf, bytes_read);
 	std::cout << "recvFrom: read " << bytes_read << " bytes" << std::endl;
 	if (isCompleteHeader(recv_buf)) {
-		t_method method = getRequestMethod(recv_buf);
-		size_t end = recv_buf.find(header_end) + header_end.length();
+		// t_method method = getRequestMethod(recv_buf);
+		size_t header_end =
+			recv_buf.find(header_terminator) + header_terminator.length();
 
-		if (method == GET) {
-			handleCompleteRequest(end, 0);
+		std::map<std::string, std::string> header_map =
+			parseHeader(recv_buf.substr(0, header_end));
 
-		} else if (method == POST) {
-			// TODO: would it be ok to try to receive everything and then
-			// later check if POST is even allowed
-			int content_length = getPostContentLength(recv_buf);
-			if (recv_buf.length() >= end + content_length) {
-				std::cout << "Buf: " << recv_buf.length() << " target: "\
-					<< end << " + " << content_length << std::endl;
-				handleCompleteRequest(end, content_length);
+		// According to subject, the first server in the config for a 
+		// particular host:port will be the default that is used for 
+		// requests that dont have server names match
+
+		// in case there is no match, uses the first config
+		ServerConfig config = configs.front();
+		// at this point all the configs we have have identical host+port
+		for (auto it = configs.begin(); it != configs.end(); it++) {
+			// select first config where header host field matches 
+			// servername
+			// TODO: have this in a try in case map::at() fails
+			// TODO: pick first match instead of last
+			for (auto itt = it->server_names.begin();
+				itt != it->server_names.end(); itt++) {
+				if (header_map.at("Host") == *itt) {
+					config = *it;
+					break ;
+				}
 			}
-			// if recv_buf is smaller than header + content length, we need to 
-			// receive more
+		}
+
+		// TODO: .at() will throw if key is not found => catch => invalid request
+		if (header_map.at("method") == "GET") {
+			handleCompleteRequest(config, header_map, header_end, 0, 0);
+
+		} else if (header_map.at("method") == "POST") {
+			handlePost(config, header_map, header_end);
 		}
 	}
 }
 
-// TODO: do not close when keepalive
+
 void Client::sendTo() {
 	std::cout << "entered sendTo()" << std::endl;
-	if (send_buf.empty()) {
+/* 	if (send_buf.empty()) {
 		if (send_queue.size() > 0) {
-			send_buf = send_queue.front();
+			send_buf = send_queue.front().response.full_response;
 		} else {
 			std::cerr << "sendTo() called with empty send_queue" << std::endl;
 		}
+	} */
+	if (send_queue.size() < 1) {
+		std::cerr << "sendTo() called with empty send_queue" << std::endl;
+		return ;
 	}
-	int bytes_sent = send(fd, send_buf.c_str(), send_buf.length(), MSG_NOSIGNAL);
+	std::string &to_send = send_queue.front().response.full_response;
+	int bytes_sent = send(fd, to_send.c_str(), to_send.length(), MSG_NOSIGNAL);
 	if (bytes_sent < 0) {
 	// TODO: currently not throwing here because maybe this is not a fatal error
 		std::cerr << "send() returned -1" << std::endl;
 	}
 	//std::cout << "sent " << bytes_sent << " bytes" << std::endl;
-	send_buf.erase(0, bytes_sent);
+	to_send.erase(0, bytes_sent);
 
-	// we have sent all responses in the queue
-	if (send_buf.empty()) {
+	std::string conn_type = "keep-alive";
+	try { //TODO: lowercase connection?
+		conn_type = send_queue.front().req_header.at("Connection");
+	} catch (...) {
+		std::cerr << "Client::sendTo(): no Connection field in header" << std::endl;
+	}
+
+	if (to_send.empty()) {
 		send_queue.erase(send_queue.begin());
-		// TODO: we can close of change mode but not both (cannot change mode
-		// on a closed connection)
-		closeConnection(epoll_fd, fd);
-		// changeEpollMode(epoll_fd, fd, EPOLLIN);
+		if (send_queue.size() == 0) {
+			// we have sent all responses in the queue
+			if (conn_type == "close" ) {
+				closeConnection(epoll_fd, fd);
+			} else { // nothing left to send
+				changeEpollMode(epoll_fd, fd, EPOLLIN);
+			}
+		}
 	}
 }


### PR DESCRIPTION
add error check when inserting clients, remove one requndant check

actually remove Client after disconnect

use unsigned value for content_length

Client: improve naming

do not completely empty recv_buffer to maybe allow pipelining

add comments

use parse_header

trigger 411 and 413, move POST logic to its own function

foundation for supporting multiple servers on one port

maybe matches config server names to header host field, but needs tests #38 

add comments

use getaddrinfo to configure socket

refactor Client and support keep-alive vs close #30

memset addrinfo to 0

use epoll_create() instead of epoll_create1() #46 