### PR TITLE
cgi_path for the executable added to LocationConfig

### DIFF
--- a/configuration/webserv.conf
+++ b/configuration/webserv.conf
@@ -39,6 +39,7 @@
 		index index.html;
 		methods GET;
 		autoindex off;				# doesn't list directory contents now. But should it?
+		cgi_path_py /usr/bin/python3;
 	}
 
 	location /images/ {				# could it be a file aswell or just folder? do we add slash at the end when missing?
@@ -66,6 +67,12 @@
 	location /puzzle {				#this is for the redirection
 		methods GET;
 		return 301 https://xkcd.com/blue_eyes.html;
+	}
+
+	location /cgi/ {
+		methods GET POST;
+		root ./www;
+		cgi_path_py /usr/bin/python3;
 	}
 }
 

--- a/inc/Request.hpp
+++ b/inc/Request.hpp
@@ -120,6 +120,7 @@ public:
 	Response							getRes();
 	ServerConfig						getConfig();
 	std::map<std::string, std::string>	getHeaders();
+	std::string							getPath();
 	LocationConfig 						getLocationConfig();
 
 	bool								getIsCgi();

--- a/inc/Structs.hpp
+++ b/inc/Structs.hpp
@@ -12,7 +12,7 @@ struct LocationConfig
 	std::string	upload_store; // not sure if a good name
 	int			return_code = 0;
 	std::string return_url = "";
-	// stuff for the cgi later cause no idea yet
+	std::string	cgi_path_py = "";
 };
 
 struct ServerConfig

--- a/src/CgiHandler.cpp
+++ b/src/CgiHandler.cpp
@@ -112,6 +112,17 @@ void	CgiHandler::launchCgi(Request &request)
 	// we have saved the post body into infile before
 	// close(input_fd); // move file position indicator to the beginning of the file stream by closing
 
+	std::string	executable = request.getLocationConfig().cgi_path_py;
+	std::string	script = request.getLocationConfig().root + request.getPath();
+
+	std::cout << "\n\nCGI_PATH: " << executable << "\n\nrequest.path: " << request.getPath() << "\n\nSCRIPT_PATH: " << script << std::endl;
+
+	char *argv[] = {
+		(char*)executable.c_str(),
+		(char*)script.c_str(),
+		nullptr
+	};
+
 	std::cout << "\n\n\n\nCGIHANDLER\n\n\n\n";
 	int pid = fork();
 
@@ -128,12 +139,6 @@ void	CgiHandler::launchCgi(Request &request)
 
 		// close(input_fd);
 		close(output_fd);
-
-		char* argv[] = {
-			(char*)"/usr/bin/python3", // absolute path to the interpreter (we get it from the location) // (char *)request.path.to_str();
-			(char*)"./www/who.py", // hardcoded now // request.root + request.path // (char *)(request.root + request.path).to_str();
-			nullptr
-		};
 		execve(argv[0], argv, envp.data());
 		// throw something ?
 	}

--- a/src/ConfigParser.cpp
+++ b/src/ConfigParser.cpp
@@ -272,6 +272,23 @@ void	validateAndParseRedirect(std::istringstream &iss, LocationConfig &location)
 	location.return_url = url;
 }
 
+void	validateAndParseCgiPython(std::istringstream &iss, LocationConfig &location)
+{
+	std::string	cgi_path;
+
+	iss >> cgi_path;
+	if (cgi_path.find(';') != cgi_path.size() - 1)
+	{
+		throw std::runtime_error("config file:\nlocation " + location.path + " cgi_path statement not ending with ';'");
+	}
+	cgi_path.pop_back();
+	if (iss >> cgi_path)
+	{
+		throw std::runtime_error("config file:\nlocation " + location.path + " upload_store contains excessive info after ;");
+	}
+	location.cgi_path_py = cgi_path;
+}
+
 LocationConfig	parseLocationConfig(std::vector<std::string> &config, std::vector<std::string>::iterator &it, std::istringstream &iss)
 {
 	LocationConfig	location;
@@ -309,6 +326,10 @@ LocationConfig	parseLocationConfig(std::vector<std::string> &config, std::vector
 		else if (key == "return")
 		{
 			validateAndParseRedirect(iss, location);
+		}
+		else if (key == "cgi_path_py")
+		{
+			validateAndParseCgiPython(iss, location);
 		}
 		else if (key == "}")
 		{

--- a/src/Request.cpp
+++ b/src/Request.cpp
@@ -167,6 +167,10 @@ std::map<std::string, std::string>	Request::getHeaders() {
 	return _headers;
 }
 
+std::string		Request::getPath(){
+	return _path;
+}
+
 bool			Request::getIsCgi() {
 	return _is_cgi;
 }


### PR DESCRIPTION
- Added a string "cgi_path_py" to the LocationConfig struct
- CGI handler is now completely linked with the config file and doesn't include anything hard coded.

