### PR TITLE
Chunked transfer

### DIFF
--- a/inc/Request.hpp
+++ b/inc/Request.hpp
@@ -4,8 +4,6 @@
 #include "StandardLibraries.hpp"
 #include "Structs.hpp"
 #include "Webserv.hpp"
-#include <fstream>
-
 
 const std::map<std::string, std::string> extensions {
 	{".aac", "audio/aac"},

--- a/inc/Request.hpp
+++ b/inc/Request.hpp
@@ -116,8 +116,7 @@ public:
 	void								initResponseStruct(int status_code);
 	bool								methodIsNotAllowed();
 	void 								printRequest(); //Remove
-	e_req_state 						handleChunked(size_t header_end,
-								 			bool isInitialRecv);
+	e_req_state 						handleChunked(size_t header_end);
 
 	//Getters
 	Response							getRes();
@@ -147,8 +146,7 @@ private:
 	int									_status_code = 200;
 	std::string							_status_code_str = "OK";
 
-	std::string							_filename_infile;
-	int									_infile_fd;
-	bool								_has_infile;
-	bool								_receiving_chunked;
+	std::string							_tmp_filename_infile;
+	bool								_has_tmp_infile = false;
+	bool								_receiving_chunked = false;
 };	

--- a/inc/Request.hpp
+++ b/inc/Request.hpp
@@ -126,8 +126,6 @@ public:
 
 	bool								getIsCgi();
 
-	e_req_state							state;
-
 private:
 	std::vector<ServerConfig>			_all_configs;
 	ServerConfig						_config;

--- a/inc/Request.hpp
+++ b/inc/Request.hpp
@@ -4,6 +4,7 @@
 #include "StandardLibraries.hpp"
 #include "Structs.hpp"
 #include "Webserv.hpp"
+#include <fstream>
 
 
 const std::map<std::string, std::string> extensions {
@@ -115,6 +116,8 @@ public:
 	void								initResponseStruct(int status_code);
 	bool								methodIsNotAllowed();
 	void 								printRequest(); //Remove
+	e_req_state 						handleChunked(size_t header_end,
+								 			bool isInitialRecv);
 
 	//Getters
 	Response							getRes();
@@ -143,4 +146,9 @@ private:
 
 	int									_status_code = 200;
 	std::string							_status_code_str = "OK";
+
+	std::string							_filename_infile;
+	int									_infile_fd;
+	bool								_has_infile;
+	bool								_receiving_chunked;
 };	

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -112,6 +112,8 @@ void Client::sendTo() {
 			}
 
 			state = SEND;
+		} else {
+			return;
 		}
 	} else {
 		if (send_queue.size() < 1) {

--- a/src/Request.cpp
+++ b/src/Request.cpp
@@ -96,7 +96,8 @@ e_req_state Request::handlePost(size_t header_end) {
 
 	// if there is transfer-encoding, then content-length can be ignored
 	if (_headers.find("transfer-encoding") != _headers.end()) {
-		if (_headers.at("transfer-encoding") == "chunked\r") {
+		if (_headers.at("transfer-encoding") == "chunked") {
+
 			std::cout << "receiving chunked transfer" << std::endl;
 			// TODO: implement checks for chunked transfer xD
 			return RECV_MORE;
@@ -131,7 +132,6 @@ e_req_state Request::handlePost(size_t header_end) {
 		handleCompleteRequest(413);
 		return READY;
 	}
-
 	// happy path
 	if (_raw_request.length() >= header_end + content_length) {
 		handleCompleteRequest(200);

--- a/src/Request.cpp
+++ b/src/Request.cpp
@@ -395,7 +395,6 @@ void Request::handleDelete()
 }
 
 void Request::handleGet() {
-	std::cout << "handleGet(): " << _path << std::endl;
 	if (_path == "/") {
 		createBody(_location.root + "/index.html");
 		if (_status_code == 200)

--- a/src/Request.cpp
+++ b/src/Request.cpp
@@ -106,7 +106,7 @@ void Request::handleCompleteRequest(int status)
 static bool extractChunks(std::string &raw_request,
 						  std::vector<std::string> &chunks)
 {
-	static int left_to_read = 0;
+	static size_t left_to_read = 0;
 	std::string chunk;
 
 	while (raw_request.length() > 0) {

--- a/src/Request.cpp
+++ b/src/Request.cpp
@@ -13,6 +13,14 @@ e_req_state	Request::addToRequest(std::string part) {
 
 	_raw_request += std::string(part);
 
+	if (receiving_chunked) {
+		e_req_state chunked_state = handleChunked(0, false);
+		if (chunked_state == RECV_MORE) {
+			return RECV_MORE;
+		}
+		handleCompleteRequest(200);
+	}
+
 	if (headerIsComplete()) {
 		size_t body_start =
 			_raw_request.find(header_terminator) + header_terminator.length();
@@ -33,6 +41,16 @@ e_req_state	Request::addToRequest(std::string part) {
 		else if (method->second == "GET") {
 			// std::cerr << "Request::addToRequest(): happy" << std::endl;
 			handleCompleteRequest(200);
+<<<<<<< HEAD
+=======
+			return READY;
+		} else if (method->second == "POST") {
+			return handlePost(body_start);
+
+		} else {
+			std::cerr << "Request::addToRequest(): unknown method" << std::endl;
+			handleCompleteRequest(400);
+>>>>>>> d615427 (draft for handleChunked)
 			return READY;
 		}
 		else if (method->second == "POST") {
@@ -86,6 +104,18 @@ void Request::handleCompleteRequest(int status)
 	getResponse(status);
 }
 
+e_req_state Request::handleChunked(size_t header_end, bool isInitialRecv) {
+	if (isInitialRecv) {
+		// skip to end of header
+		// create file
+		// write to file
+		// erase raw_request
+	} else {
+		//append to file
+		//erase raw_request
+	}
+}
+
 e_req_state Request::handlePost(size_t header_end) {
 	//method is not allowed in config
 	initResponseStruct(200);
@@ -100,7 +130,7 @@ e_req_state Request::handlePost(size_t header_end) {
 
 			std::cout << "receiving chunked transfer" << std::endl;
 			// TODO: implement checks for chunked transfer xD
-			return RECV_MORE;
+			return handleChunked(header_end, true);
 		}
 		// header has transfer-encoding but it is not set to chunked =>
 		// we proceed to look for content-length


### PR DESCRIPTION
Puts the received data in a file under `/tmp` and writes the filename into `Request::_tmp_filename_infile`. Also sets the bool `Request::_has_tmp_infile`

test with somethin like: `curl -X POST -H "Transfer-Encoding: chunked" --data-binary @path/to/file 127.0.0.1:8080/uploads`