### PR TITLE
Signal handling for SIGINT and SIGTERM and closing open fds after

### DIFF
--- a/inc/StandardLibraries.hpp
+++ b/inc/StandardLibraries.hpp
@@ -3,26 +3,27 @@
 
 #include <algorithm>
 #include <asm-generic/socket.h>
+#include <atomic>
 #include <cstddef> // for size_t?
 #include <cstdio> // remove
+#include <csignal>
 #include <exception>
 #include <fcntl.h> // fcntl() // only for MacOS?
 #include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <map>
+#include <netdb.h> // struct addrinfo
 #include <netinet/in.h>
 #include <regex>
 #include <sstream> // for istrinstream
 #include <stdexcept>
 #include <string>
 #include <string.h> //memset
-//#include <strings.h>
 #include <sys/epoll.h>
 #include <sys/socket.h>
+#include <sys/wait.h>
 // #include <sys/types.h>
-#include <netdb.h> // struct addrinfo
 #include <unistd.h> // 
 #include <vector>
-#include <sys/wait.h>
 

--- a/inc/event_loop.hpp
+++ b/inc/event_loop.hpp
@@ -4,4 +4,6 @@
 #include "Structs.hpp"
 
 const static int _CLIENT_TIMEOUT_S = 10;
-int eventLoop(std::vector<ServerConfig>);
+
+int		eventLoop(std::vector<ServerConfig>);
+void	handle_signal(int sig);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,6 +13,8 @@ int	main(int argc, char **argv)
 			std::cout << "main(): using default config file" << std::endl;
 			server_configs = configParser((char *)"configuration/webserv.conf");
 		}
+		// signal(SIGINT, handle_signal);
+		// signal(SIGTERM, handle_signal);
 		eventLoop(server_configs);
 		// TODO add error for too many args?
 	} catch (std::exception &e) {


### PR DESCRIPTION
We have a signal handler (handle_signal()) which updates std::atomic<bool> signal_stop as true when SIGTERM of SIGINT are received. Inside eventloop we check for this after epoll_wait() and proceed to close client fds and sockets.